### PR TITLE
Fix build command on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ $ pyinstaller mathinspector.linux.spec
 
 or
 
-$ pyinstaller mathinspector.windows.spec
+$ pyinstaller mathinspector.win.spec
 
 ## OpenGL Error on MacOS
 see the solution in this issue if OpenGL is not working on macos https://github.com/PixarAnimationStudios/USD/issues/1372


### PR DESCRIPTION
I was following the installation instructions given in `INSTALL.md` and running `pyinstaller mathinspector.windows.spec` threw an error `spec "mathinspector.windows.spec" not found`. The spec file is actually named `mathinspector.win.spec`. So I ran `pyinstaller mathinspector.win.spec` and it worked. Great work btw, I just got started and I'm looking forward to exploring the software further. Thanks!