### PR TITLE
add environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,21 @@
+name: mathinspector
+channels:
+- conda-forge
+- defaults
+dependencies:
+- PyInstaller
+- PyOpenGL
+- cloudpickle
+- numpy
+- pillow
+- scikit-image
+- scipy
+- watchdog
+- pip:
+  - PyOpenGL_accelerate
+  - pygame
+  - pyglm
+  - ttkthemes
+# base
+- python<3.9
+- pip


### PR DESCRIPTION
Can make it easier/more reliable to install cross-platform.

Ideally should package properly (so can `pip install mathinspector` - vis #19) instead, but this works for now.

```bash
git clone https://github.com/casperdcl/MathInspector
cd MathInspector
conda env create
conda activate mathinspector
pyinstaller mathinspector.linux.spec
python mathinspector
```