### PR TITLE
auto-release tags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+    - run: pip install .
+    - id: dist
+      uses: casperdcl/deploy-pypi@v2
+      with:
+        build: true
+        password: ${{ secrets.PYPI_TOKEN }}
+        upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
+    - name: Changes
+      run: |
+        git log --pretty='format:%d%n- %s%n%b---' $(git tag --sort=v:refname | tail -n2 | head -n1)..HEAD > _CHANGES.md
+    - if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Math Inspector ${{ github.ref }} (Beta)
+        body_path: _CHANGES.md
+        draft: true
+    - if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ steps.dist.outputs.whl }}
+        asset_name: ${{ steps.dist.outputs.whl }}
+        asset_content_type: application/zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - run: pip install .
     - id: dist
       uses: casperdcl/deploy-pypi@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-mathinspector/version.py
+mathinspector/_dist_version.py
 .Python
 build/
 develop-eggs/

--- a/mathinspector/version.py
+++ b/mathinspector/version.py
@@ -1,0 +1,9 @@
+"""version detector. Precedence: installed dist, git, 'UNKNOWN'."""
+try:
+    from ._dist_ver import VERSION
+except ImportError:
+    try:
+        from setuptools_scm import get_version
+        VERSION = get_version(root='..', relative_to=__file__)
+    except (ImportError, LookupError):
+        VERSION = "UNKNOWN"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "mathinspector/version.py"
+write_to = "mathinspector/_dist_version.py"
 write_to_template = 'VERSION = "{version}"'

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers=
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Topic :: Artistic Software
     Topic :: Documentation


### PR DESCRIPTION
- auto-draft GitHub releases on git tags
- auto-upload to PyPI on git tags
- make sure running locally without installing displays correct version

P.S. Python 3.9 doesn't seem to work due to PyOpenGL being broken https://github.com/MathInspector/MathInspector/runs/1930714684?check_suite_focus=true