### PR TITLE
fix PyPI deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,11 @@ jobs:
     - id: dist
       uses: casperdcl/deploy-pypi@v2
       with:
+        requirements: twine setuptools wheel setuptools_scm[toml]
         build: true
         password: ${{ secrets.PYPI_TOKEN }}
         upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
-    - name: Changes
+    - name: Changelog
       run: |
         git log --pretty='format:%d%n- %s%n%b---' $(git tag --sort=v:refname | tail -n2 | head -n1)..HEAD > _CHANGES.md
     - if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,7 @@ jobs:
     - id: dist
       uses: casperdcl/deploy-pypi@v2
       with:
-        requirements: twine setuptools wheel setuptools_scm[toml]
-        build: true
+        pip: true
         password: ${{ secrets.PYPI_TOKEN }}
         upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
     - name: Changelog

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ parts/
 sdist/
 var/
 wheels/
+*.whl
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
- [x] correct version
- [x] add `*.whl` to `.gitignore`
- [x] auto-determine requirements using https://github.com/casperdcl/deploy-pypi/pull/10

@calhoun137 this seems inconsistent:

https://github.com/MathInspector/MathInspector/blob/f1488d48c0f98b9b16ae7facc6b3cc3097edf3c4/mathinspector/util/config.py#L31

and

https://github.com/MathInspector/MathInspector/blob/f1488d48c0f98b9b16ae7facc6b3cc3097edf3c4/pkg/mathinspector.macos.spec#L13

... does "Resources" get magically created by PyInstaller just on macos?